### PR TITLE
add routing for `/rooms/:room?`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,3 @@
+exports.randomString = function () {
+  return (Math.random() + 1).toString(36).substring(7);
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "browserify": "^9.0.3",
     "express": "^4.12.2",
     "extend": "1.1.3",
+    "grapnel": "^0.5.8",
+    "query-string": "^1.0.0",
     "socket.io": "^1.3.5",
     "underscore": "^1.8.2",
     "voxel": "~0.5.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 var fs = require('fs');
 
+var utils = require('./lib/utils');
+
 // Socket.io mapping.
 var sockets = {};
 
@@ -9,6 +11,12 @@ var app = express();
 var server = require('http').createServer(app);
 var io = require('socket.io')(server);
 var port = process.env.PORT || 3000;
+
+// Routes that should render `/index.html` and get routed on the client.
+const SPA_ROUTES = [
+  '/room/:room'
+];
+
 
 app.use('/js/', express.static(__dirname + '/build/js'));
 app.use('/css/', express.static(__dirname + '/build/css'));
@@ -24,6 +32,23 @@ io.on('connection', function (socket) {
 
   socket.on('move', function (data) {
   });
+});
+
+app.get('/room/:room?', function (req, res, next) {
+  var roomName = req.params.room;
+
+  if (!roomName) {
+    res.redirect('/room/' + utils.randomString());
+    return;
+  }
+
+  next();
+});
+
+SPA_ROUTES.forEach(function (route) {
+  app.get(route, function (req, res) {
+    res.sendFile(__dirname + '/src/index.html');
+  })
 });
 
 server.listen(port, function () {

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -1,13 +1,30 @@
-var createGame = require('voxel-engine')
-var extend = require('extend')
-var fly = require('voxel-fly')
-var highlight = require('voxel-highlight')
-var player = require('voxel-player')
-var voxel = require('voxel')
-var walk = require('voxel-walk')
+var urllib = require('url');
+var qs = require('query-string');
+
+var extend = require('extend');
+var Grapnel = require('grapnel');
+
+var createGame = require('voxel-engine');
+var fly = require('voxel-fly');
+var highlight = require('voxel-highlight');
+var player = require('voxel-player');
+var voxel = require('voxel');
+var walk = require('voxel-walk');
+
+var utils = require('../../lib/utils');
 
 
 module.exports = function (opts, setup) {
+  var GET = qs.parse(window.location.search);
+  var router = new Grapnel({pushState: true});
+
+  router.navigate(window.location.href);
+
+  router.get('/room/:room', function (req) {
+    var roomName = req.params.room;
+    console.log('room: %s', roomName);
+  });
+
   setup = setup || defaultSetup
   var defaults = {
     generate: voxel.generator.Valley,


### PR DESCRIPTION
Loading [`http://localhost:3000/rooms/seavanworld`](http://localhost:3000/rooms/seavanworld) will load [`/index.html`](http://localhost:3000/) and give you access to the `seavanworld` name.

Loading [`http://localhost:3000/rooms/`](http://localhost:3000/rooms/) will redirect to a random room name, such as [`http://localhost:3000/rooms/6l7ycoywrk9`](http://localhost:3000/rooms/6l7ycoywrk9)
