### PR TITLE
Fix multi-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/KevinGrandon/etherworld/issues"
   },
   "homepage": "https://github.com/KevinGrandon/etherworld",
+  "engines": {
+    "node": "0.10.31"
+  },
   "dependencies": {
     "autoprefixer": "^5.1.0",
     "babelify": "^5.0.4",


### PR DESCRIPTION
All we needed was to lock down the node version. Seems one of the dependencies breaks on 0.12.x.  =(
